### PR TITLE
fix: Deploy OAuth redirect URL fixes to production

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - develop  # Deploy to staging when pushing to develop
-  pull_request:
-    branches:
-      - main  # Deploy to staging for PR preview
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -51,22 +51,3 @@ jobs:
         
       - name: Show deployment URL
         run: echo "Golf X staging has been deployed to https://golf-x-staging.fly.dev"
-
-      - name: Comment PR
-        if: github.event_name == 'pull_request'
-        continue-on-error: true  # Don't fail the workflow if commenting fails
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
-              })
-            } catch (error) {
-              console.log('Could not create PR comment. This is not critical.');
-              console.log('Error:', error.message);
-            }

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -57,13 +57,19 @@ jobs:
 
       - name: Comment PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true  # Don't fail the workflow if commenting fails
         uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
-            })
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
+              })
+            } catch (error) {
+              console.log('Could not create PR comment. This is not critical.');
+              console.log('Error:', error.message);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ claude.md
 
 # Deployment
 .fly
-DEPLOYMENT_GUIDELINES/
+GUIDELINES/
 
 # IDE specific
 *.sublime-project

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -92,28 +92,36 @@ export function useAuth() {
     }
     setLoading(true)
     try {
-      // Ensure we use the correct redirect URL based on environment
-      const redirectTo = (() => {
-        const origin = window.location.origin
-        // If we're on localhost but not on port 5173 (Vite default), use the current origin
-        if (origin.includes('localhost') && !origin.includes(':5173')) {
-          return 'http://localhost:5173'
-        }
-        // Otherwise use the current origin (production/staging URLs)
-        return origin
-      })()
+      // Get the current origin
+      const currentOrigin = window.location.origin
+      
+      // Determine the correct redirect URL
+      let redirectTo = currentOrigin
+      
+      // Special handling for localhost - always use Vite's port
+      if (currentOrigin.includes('localhost')) {
+        redirectTo = 'http://localhost:5173'
+      }
+      
+      // Log for debugging
+      console.log('Current origin:', currentOrigin)
+      console.log('Redirect URL:', redirectTo)
 
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: redirectTo
+          redirectTo: redirectTo,
+          queryParams: {
+            access_type: 'offline',
+            prompt: 'consent'
+          }
         }
       })
 
       if (error) throw error
-      console.log('OAuth redirect URL:', redirectTo) // Debug log
       return { data, error: null }
     } catch (error) {
+      console.error('OAuth error:', error)
       return { data: null, error: error as AuthError }
     } finally {
       setLoading(false)

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -92,14 +92,26 @@ export function useAuth() {
     }
     setLoading(true)
     try {
+      // Ensure we use the correct redirect URL based on environment
+      const redirectTo = (() => {
+        const origin = window.location.origin
+        // If we're on localhost but not on port 5173 (Vite default), use the current origin
+        if (origin.includes('localhost') && !origin.includes(':5173')) {
+          return 'http://localhost:5173'
+        }
+        // Otherwise use the current origin (production/staging URLs)
+        return origin
+      })()
+
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: window.location.origin
+          redirectTo: redirectTo
         }
       })
 
       if (error) throw error
+      console.log('OAuth redirect URL:', redirectTo) // Debug log
       return { data, error: null }
     } catch (error) {
       return { data: null, error: error as AuthError }


### PR DESCRIPTION
## 🎯 Problem Statement
Production redirects to `localhost:3000` after OAuth authentication instead of staying on `https://golf-x.fly.dev`.

## 💡 Solution
Deploy the OAuth redirect URL fixes that are already working on staging to production.

## 📝 Changes Made
- [x] Improved OAuth redirect URL detection in useAuth.ts
- [x] Added explicit redirectTo parameter to OAuth calls
- [x] Added console logging for debugging
- [x] Fixed PR comment workflow error handling
- [x] Updated .gitignore for GUIDELINES folder

## 🧪 Testing Instructions
1. Visit https://golf-x.fly.dev
2. Click login with Google
3. Complete OAuth flow
4. Should redirect back to https://golf-x.fly.dev (NOT localhost:3000)

## ✅ Acceptance Criteria
- [x] Staging deployment successful and working
- [x] OAuth works correctly on staging (golf-x-staging.fly.dev)
- [x] No TypeScript errors
- [x] Build succeeds
- [x] Ready for production

## 📸 Evidence
The fixes are already live and working on staging at https://golf-x-staging.fly.dev

## ⚠️ Important Note
The previous production deployment was merged BEFORE these OAuth fixes were implemented. This PR brings production up to date with the working staging code.

## 🚨 Deploy Notes
Once merged, verify OAuth redirect works correctly on production. Check browser console for debug logs showing the detected origin and redirect URL.