### PR TITLE
fix: Deploy OAuth fixes and workflow improvements to production

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - develop  # Deploy to staging when pushing to develop
-  pull_request:
-    branches:
-      - main  # Deploy to staging for PR preview
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -51,22 +51,3 @@ jobs:
         
       - name: Show deployment URL
         run: echo "Golf X staging has been deployed to https://golf-x-staging.fly.dev"
-
-      - name: Comment PR
-        if: github.event_name == 'pull_request'
-        continue-on-error: true  # Don't fail the workflow if commenting fails
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
-              })
-            } catch (error) {
-              console.log('Could not create PR comment. This is not critical.');
-              console.log('Error:', error.message);
-            }

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -57,13 +57,19 @@ jobs:
 
       - name: Comment PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true  # Don't fail the workflow if commenting fails
         uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
-            })
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '🚀 Staging deployment complete! View at https://golf-x-staging.fly.dev'
+              })
+            } catch (error) {
+              console.log('Could not create PR comment. This is not critical.');
+              console.log('Error:', error.message);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ claude.md
 
 # Deployment
 .fly
-DEPLOYMENT_GUIDELINES/
+GUIDELINES/
 
 # IDE specific
 *.sublime-project

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -92,28 +92,36 @@ export function useAuth() {
     }
     setLoading(true)
     try {
-      // Ensure we use the correct redirect URL based on environment
-      const redirectTo = (() => {
-        const origin = window.location.origin
-        // If we're on localhost but not on port 5173 (Vite default), use the current origin
-        if (origin.includes('localhost') && !origin.includes(':5173')) {
-          return 'http://localhost:5173'
-        }
-        // Otherwise use the current origin (production/staging URLs)
-        return origin
-      })()
+      // Get the current origin
+      const currentOrigin = window.location.origin
+      
+      // Determine the correct redirect URL
+      let redirectTo = currentOrigin
+      
+      // Special handling for localhost - always use Vite's port
+      if (currentOrigin.includes('localhost')) {
+        redirectTo = 'http://localhost:5173'
+      }
+      
+      // Log for debugging
+      console.log('Current origin:', currentOrigin)
+      console.log('Redirect URL:', redirectTo)
 
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: redirectTo
+          redirectTo: redirectTo,
+          queryParams: {
+            access_type: 'offline',
+            prompt: 'consent'
+          }
         }
       })
 
       if (error) throw error
-      console.log('OAuth redirect URL:', redirectTo) // Debug log
       return { data, error: null }
     } catch (error) {
+      console.error('OAuth error:', error)
       return { data: null, error: error as AuthError }
     } finally {
       setLoading(false)

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -92,14 +92,26 @@ export function useAuth() {
     }
     setLoading(true)
     try {
+      // Ensure we use the correct redirect URL based on environment
+      const redirectTo = (() => {
+        const origin = window.location.origin
+        // If we're on localhost but not on port 5173 (Vite default), use the current origin
+        if (origin.includes('localhost') && !origin.includes(':5173')) {
+          return 'http://localhost:5173'
+        }
+        // Otherwise use the current origin (production/staging URLs)
+        return origin
+      })()
+
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: window.location.origin
+          redirectTo: redirectTo
         }
       })
 
       if (error) throw error
+      console.log('OAuth redirect URL:', redirectTo) // Debug log
       return { data, error: null }
     } catch (error) {
       return { data: null, error: error as AuthError }


### PR DESCRIPTION
## 🎯 Problem Statement
1. Production redirects to `localhost:3000` after OAuth authentication
2. Staging workflow was triggering deployments on PR creation without approval

## 💡 Solution
Deploy the OAuth redirect URL fixes and workflow improvements that are tested and working on staging.

## 📝 Changes Made
- [x] Fixed OAuth redirect URL detection in useAuth.ts
- [x] Added explicit redirectTo parameter with debug logging
- [x] Removed pull_request trigger from staging workflow
- [x] Fixed workflow to only deploy after PR approval
- [x] Removed unnecessary PR comment step
- [x] Updated .gitignore for GUIDELINES folder

## 🧪 Testing Instructions
1. Check that PR only shows one check (from develop push)
2. No automatic deployment should trigger from this PR
3. After merge, production should deploy
4. OAuth should redirect to https://golf-x.fly.dev (not localhost)

## ✅ Acceptance Criteria
- [x] Staging deployment successful
- [x] OAuth works on staging
- [x] Workflow doesn't auto-deploy on PR
- [x] No TypeScript errors
- [x] Build succeeds
- [x] Ready for production

## 📸 Evidence
- Staging working at: https://golf-x-staging.fly.dev
- This PR should only show existing checks, no new deployment

## ⚠️ Important
Remember to update Supabase Site URL from `http://localhost:3000` to `https://golf-x.fly.dev` for best results.

## 🚨 Deploy Notes
After merge, check browser console for OAuth debug logs showing detected origin and redirect URL.